### PR TITLE
MAINT: pin the version of sphinx-gallery to 0.7

### DIFF
--- a/doc/gh-environment.yml
+++ b/doc/gh-environment.yml
@@ -22,7 +22,7 @@ dependencies:
     - nbformat
     - nbconvert!=5.4
     - sphinxcontrib-bibtex
-    - sphinx-gallery
+    - sphinx-gallery==0.7
     - sphinx_bootstrap_theme
     - sphinx_panels
     - git+https://github.com/cogent3/cogent3.git@develop#egg=cogent3[dev]


### PR DESCRIPTION
[CHANGED] version pinned in the conda environment since
    gallery images not being generated under sphinx-gallery 0.8